### PR TITLE
Investigate xpm none map transparency

### DIFF
--- a/src/ft_render_map.c
+++ b/src/ft_render_map.c
@@ -15,7 +15,7 @@
 int		ft_render_map(t_game *game);
 void	ft_identify_sprite(t_game *game, int x, int y);
 void	ft_render_player(t_game *game, int x, int y);
-void	ft_render_sprite(t_game *game, t_image sprite, int column, int line);
+void	ft_render_sprite(t_game *game, t_image sprite, int line, int column);
 void	ft_print_movements(t_game *game);
 
 int	ft_render_map(t_game *game)
@@ -73,6 +73,10 @@ void	ft_render_player(t_game *game, int y, int x)
 
 void	ft_render_sprite(t_game *game, t_image sprite, int line, int column)
 {
-	mlx_put_image_to_window (game->mlx_ptr, game->win_ptr, \
-	sprite.xpm_ptr, column * sprite.x, line * sprite.y);
+    /* Draw base floor first so transparent (None) areas show it */
+    mlx_put_image_to_window(game->mlx_ptr, game->win_ptr, \
+    game->floor.xpm_ptr, column * IMG_WIDTH, line * IMG_HEIGHT);
+    /* Overlay the requested sprite */
+    mlx_put_image_to_window(game->mlx_ptr, game->win_ptr, \
+    sprite.xpm_ptr, column * sprite.x, line * sprite.y);
 }

--- a/src/so_long.h
+++ b/src/so_long.h
@@ -132,7 +132,7 @@ t_image	ft_new_sprite(void *mlx, char *path, t_game *game);
 int		ft_render_map(t_game *game);
 void	ft_identify_sprite(t_game *game, int x, int y);
 void	ft_render_player(t_game *game, int x, int y);
-void	ft_render_sprite(t_game *game, t_image sprite, int column, int line);
+void	ft_render_sprite(t_game *game, t_image sprite, int line, int column);
 int		ft_handle_input(int keysym, t_game *game);
 void	ft_player_move(t_game *game, int x, int y, int player_sprite);
 int		ft_victory(t_game *game);


### PR DESCRIPTION
Modify `ft_render_sprite` to draw the floor first, then the sprite, to enable transparency for XPM `None` areas.

The `ft_render_sprite` function was updated to first draw the `game->floor` image at the tile's position, and then overlay the given `sprite`. This ensures that any `None` (transparent) pixels in the `sprite` will reveal the underlying floor image, achieving the desired visual effect for sprites like `player.xpm` and `door.xpm`. Additionally, the parameter order for `ft_render_sprite` was corrected in both its definition and declaration to `(game, sprite, line, column)`.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe3948bf-a7f9-42bc-a0b1-5db6da319e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe3948bf-a7f9-42bc-a0b1-5db6da319e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

