### PR TITLE
Fix floor transparency when set to none

### DIFF
--- a/src/ft_render_map.c
+++ b/src/ft_render_map.c
@@ -23,6 +23,8 @@ int	ft_render_map(t_game *game)
 		x = 0;
 		while (x < game->map.columns)
 		{
+            // Always draw floor first so transparent sprites overlay correctly
+            ft_render_sprite(game, game->floor, y, x);
 			ft_identify_sprite(game, y, x);
 			x++;
 		}
@@ -36,10 +38,8 @@ void	ft_identify_sprite(t_game *game, int y, int x)
 	char	parameter;
 
 	parameter = game->map.full[y][x];
-	if (parameter == WALL)
+    if (parameter == WALL)
 		ft_render_sprite (game, game->wall, y, x);
-	else if (parameter == FLOOR)
-		ft_render_sprite (game, game->floor, y, x);
 	else if (parameter == COINS)
 		ft_render_sprite (game, game->coins, y, x);
 	else if (parameter == MAP_EXIT)

--- a/src/so_long.h
+++ b/src/so_long.h
@@ -148,9 +148,9 @@ void	ft_check_for_empty_line(char *map, t_game *game);
 
 //ft_render_map.c
 int		ft_render_map(t_game *game);
-void	ft_identify_sprite(t_game *game, int x, int y);
+void	ft_identify_sprite(t_game *game, int y, int x);
 void	ft_render_player(t_game *game, int x, int y);
-void	ft_render_sprite(t_game *game, t_image sprite, int column, int line);
+void	ft_render_sprite(t_game *game, t_image sprite, int line, int column);
 
 //ft_utils.c
 char	*ft_strappend(char **s1, const char *s2);


### PR DESCRIPTION
Adjust sprite rendering order to ensure transparent sprites correctly overlay the floor, and synchronize function prototypes.

The user reported issues with transparency on the floor. While the floor's XPM does not define a transparent color, this change ensures that other sprites (e.g., player, coins) which *do* use 'None' for transparency will correctly display the floor underneath them. This resolves rendering order conflicts and includes minor fixes for function prototype consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-d22d888b-314d-40d8-a7d4-3df35b293c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d22d888b-314d-40d8-a7d4-3df35b293c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

