### PR TITLE
Check for unreachable coins in so_long

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ SRCS = main.c \
 	   ft_init_game.c \
 	   ft_init_map.c \
 	   ft_render_map.c \
-	   ft_utils.c \
+       ft_utils.c \
+       ft_path_check.c \
 	   get_next_line.c
 
 # Object files

--- a/src/ft_check_map.c
+++ b/src/ft_check_map.c
@@ -19,6 +19,7 @@ void	ft_check_map(t_game *game)
 	ft_check_columns(game);
 	ft_count_map_parameters(game);
 	ft_verify_map_parameters(game);
+    ft_check_reachability(game);
 }
 
 static int	ft_line_length(const char *line)

--- a/src/ft_path_check.c
+++ b/src/ft_path_check.c
@@ -1,0 +1,90 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_path_check.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mkazuhik <mkazuhik@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/25 17:22:41 by mkazuhik          #+#    #+#             */
+/*   Updated: 2025/09/25 17:22:41 by mkazuhik         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "so_long.h"
+
+static char	**ft_dup_map(char **src, int rows)
+{
+    char    **dup;
+    int     i;
+
+    dup = (char **)ft_calloc(rows + 1, sizeof(char *));
+    if (!dup)
+        return (NULL);
+    i = 0;
+    while (i < rows)
+    {
+        dup[i] = ft_strdup(src[i]);
+        if (!dup[i])
+        {
+            while (--i >= 0)
+                free(dup[i]);
+            free(dup);
+            return (NULL);
+        }
+        i++;
+    }
+    dup[rows] = NULL;
+    return (dup);
+}
+
+static void	ft_free_dup_map(char **map, int rows)
+{
+    int i;
+
+    if (!map)
+        return ;
+    i = 0;
+    while (i < rows)
+    {
+        free(map[i]);
+        i++;
+    }
+    free(map);
+}
+
+static int	ft_is_walkable(char c)
+{
+    return (c == FLOOR || c == COINS || c == PLAYER);
+}
+
+static void	ft_flood_fill(char **grid, int rows, int cols, int y, int x, int *coins)
+{
+    if (y < 0 || y >= rows || x < 0 || x >= cols)
+        return ;
+    if (!ft_is_walkable(grid[y][x]))
+        return ;
+    if (grid[y][x] == COINS)
+        (*coins)++;
+    grid[y][x] = 'V';
+    ft_flood_fill(grid, rows, cols, y - 1, x, coins);
+    ft_flood_fill(grid, rows, cols, y + 1, x, coins);
+    ft_flood_fill(grid, rows, cols, y, x - 1, coins);
+    ft_flood_fill(grid, rows, cols, y, x + 1, coins);
+}
+
+void	ft_check_reachability(t_game *game)
+{
+    char	**dup;
+    int		reachable_coins;
+
+    dup = ft_dup_map(game->map.full, game->map.rows);
+    if (!dup)
+        ft_error_msg("Memory allocation failed during path check.", game);
+    reachable_coins = 0;
+    ft_flood_fill(dup, game->map.rows, game->map.columns,
+        game->map.player.y, game->map.player.x, &reachable_coins);
+    ft_free_dup_map(dup, game->map.rows);
+    if (reachable_coins < game->map.coins)
+        ft_error_msg("Invalid Map. There are unreachable Coins!", game);
+}
+

--- a/src/so_long.h
+++ b/src/so_long.h
@@ -121,6 +121,9 @@ void	ft_count_map_parameters(t_game *game);
 void	ft_verify_map_parameters(t_game *game);
 void	ft_check_rectangle(t_game *game);
 
+// ft_path_check.c
+void	ft_check_reachability(t_game *game);
+
 //ft_close_game.c
 int		ft_victory(t_game *game);
 int		ft_close_game(t_game *game);


### PR DESCRIPTION
Add a flood-fill reachability check to `ft_check_map` to ensure all coins are collectible.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b5269cd-6976-4277-85c1-ddbd53eeb459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b5269cd-6976-4277-85c1-ddbd53eeb459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

